### PR TITLE
rtlwifi_new: rtl8192cu: support D-Link DWA-131

### DIFF
--- a/rtl8192cu/sw.c
+++ b/rtl8192cu/sw.c
@@ -376,6 +376,7 @@ static struct usb_device_id rtl8192c_usb_ids[] = {
 	{RTL_USB_DEVICE(0x2001, 0x3307, rtl92cu_hal_cfg)}, /*D-Link-Cameo*/
 	{RTL_USB_DEVICE(0x2001, 0x3309, rtl92cu_hal_cfg)}, /*D-Link-Alpha*/
 	{RTL_USB_DEVICE(0x2001, 0x330a, rtl92cu_hal_cfg)}, /*D-Link-Alpha*/
+	{RTL_USB_DEVICE(0x2001, 0x330d, rtl92cu_hal_cfg)}, /*D-Link DWA-131 */
 	{RTL_USB_DEVICE(0x2019, 0xab2b, rtl92cu_hal_cfg)}, /*Planex -Abocom*/
 	{RTL_USB_DEVICE(0x20f4, 0x624d, rtl92cu_hal_cfg)}, /*TRENDNet*/
 	{RTL_USB_DEVICE(0x2357, 0x0100, rtl92cu_hal_cfg)}, /*TP-Link WN8200ND*/


### PR DESCRIPTION
Add USB ID 2001:330D to rtl8192cu to support D-Link DWA-131. See
http://bernaerts.dyndns.org/linux/74-ubuntu/277-ubuntu-precise-dwa-131-rev-b1.

I have one of these devices and I can confirm that the process described by the above blogpost works. It would be better if the device worked out of the box, though, hence the suggested patch. I have to confess that I have not tested this patch, only the process of adding the ID manually as described by the post, so hopefully this is the right change to make.
