### PR TITLE
Allow KVER to be defined on the make cmdline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,7 @@ x509.genkey
 
 # Kconfig presets
 all.config
+
+# Driver backups
+backup_drivers.tar
+

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/sh
 CC = gcc
-KVER  := $(shell uname -r)
+KVER  ?= $(shell uname -r)
 KSRC := /lib/modules/$(KVER)/build
 FIRMWAREDIR := /lib/firmware/
 PWD := $(shell pwd)


### PR DESCRIPTION
Saves a reboot on kernel updates.
ex: ```KVER=4.6-custom make; sudo sh -c "KVER=4.6-custom make install"```

Also add ```backup_drivers.tar``` to ```.gitignore```.