### PR TITLE
Fix "Unknown symbol _rtl_dbg_trace"

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -84,10 +84,10 @@ void rtl_dbgp_flag_init(struct ieee80211_hw *hw)
 }
 EXPORT_SYMBOL_GPL(rtl_dbgp_flag_init);
 
-#ifdef CONFIG_RTLWIFI_DEBUG
 void _rtl_dbg_trace(struct rtl_priv *rtlpriv, int comp, int level,
 		    const char *modname, const char *fmt, ...)
 {
+#ifdef CONFIG_RTLWIFI_DEBUG
 	if (unlikely((comp & rtlpriv->dbg.global_debugcomponents) &&
 		     (level <= rtlpriv->dbg.global_debuglevel))) {
 		struct va_format vaf;
@@ -105,6 +105,6 @@ void _rtl_dbg_trace(struct rtl_priv *rtlpriv, int comp, int level,
 
 		va_end(args);
 	}
+#endif
 }
 EXPORT_SYMBOL_GPL(_rtl_dbg_trace);
-#endif


### PR DESCRIPTION
When I tried to use the newest version, I ended up getting "Unknown symbol _rtl_dbg_trace" to dmesg.

If CONFIG_RTLWIFI_DEBUG was not defined, then _rtl_dbg_trace() was declared in debug.h, but not defined in debug.c.

This is rather ugly fix, but at least you don't end up without internet connection :)