### PR TITLE
Set fw_ready properly for rtl8192cu.

### DIFF
--- a/rtl8192cu/hw.c
+++ b/rtl8192cu/hw.c
@@ -975,6 +975,7 @@ int rtl92cu_hw_init(struct ieee80211_hw *hw)
 	local_save_flags(flags);
 	local_irq_enable();
 
+	rtlhal->fw_ready = false;
 	rtlhal->hw_type = HARDWARE_TYPE_RTL8192CU;
 	err = _rtl92cu_init_mac(hw);
 	if (err) {
@@ -988,6 +989,7 @@ int rtl92cu_hw_init(struct ieee80211_hw *hw)
 		err = 1;
 		goto exit;
 	}
+	rtlhal->fw_ready = true;
 	rtlhal->last_hmeboxnum = 0; /* h2c */
 	_rtl92cu_phy_param_tab_init(hw);
 	rtl92cu_phy_mac_config(hw);


### PR DESCRIPTION
While debugging the kernel panic when using my rtl8192cu dongle I noticed log messages
such as:
```
rtl8192c_common:rtl92c_fill_h2c_cmd(): return H2C cmd because of Fw download fail!!!
rtl8192cu:rtl92cu_set_hw_reg():<0-0> switch case not processed
```
I was able to determine this was a result of the fw_ready flag not being set in rtl92cu_hw_init. The other users in the repo were setting this based on the result of  rtl92c_download_fw.
I applied this patch and the warning is gone.

I am not aware of what kind of behavior this might change. It seems to be working for me.


