### PR TITLE
Fix markdown syntax errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,29 +15,35 @@ If you are looking for the driver for rtl8822be or rtl8723de, then execute the f
 git checkout origin/extended -b extended
 
 #### Installation instruction
-You can find <<YOUR WIRELESS DRIVER CODE>> using `lspci | grep Wireless`.
+You can find `<<YOUR WIRELESS DRIVER CODE>>` using `lspci | grep Wireless`.
 Afterwards, execute the following lines of codes in your shell:  
   
-```
+
 You will need to install "make", "gcc", "kernel headers", "kernel build essentials", and "git".
 
 If you are running Ubuntu, then
 
- sudo apt-get install linux-headers-generic build-essential git
+```sh
+sudo apt-get install linux-headers-generic build-essential git
+```
 
 Please note the first paragraph above.
 
 For all distros:
+```
 git clone https://github.com/lwfinger/rtlwifi_new.git
 cd rtlwifi_new
 sudo make install
 sudo modprobe -r <<YOUR WIRELESS DRIVER CODE>>
 sudo modprobe <<YOUR WIRELESS DRIVER CODE>>
+```
 
 #### Option configuration
 If it turns out that your system needs one of the configuration options, then do the following:
 
+```
 vim /etc/modprobe.d/<<YOUR WIRELESS DRIVER CODE>>.conf 
+```
 
 There, enter the line below:
 `options <<YOUR WIRELESS DRIVER CODE>> <<driver_option_name>>=<value>`


### PR DESCRIPTION
README.md wasn't displaying properly on Github; everything past the deleted \`\`\` was formatted as code, and `<<YOUR WIRELESS DRIVER CODE>>` appeared as &lt;&gt;.