### PR TITLE
Fix alignment fault on AARCH64 (Marvell Armada)

### DIFF
--- a/rtl8821ae/hw.c
+++ b/rtl8821ae/hw.c
@@ -1122,7 +1122,7 @@ static u8 _rtl8821ae_dbi_read(struct rtl_priv *rtlpriv, u16 addr)
 	}
 	if (0 == tmp) {
 		read_addr = REG_DBI_RDATA + addr % 4;
-		ret = rtl_read_word(rtlpriv, read_addr);
+		ret = rtl_read_byte(rtlpriv, read_addr);
 	}
 	return ret;
 }


### PR DESCRIPTION
This fixes an alignment fault kernel panic on AARCH64 platforms, specifically the Marvell Armada chip in the espressobin network-oriented SBC but also probably other AARCH64 chips that don't like unaligned access.