### PR TITLE
rtlwifi_new: adapt last_suspend_sec for linux 5.6 builds

### DIFF
--- a/wifi.h
+++ b/wifi.h
@@ -1625,7 +1625,11 @@ struct rtl_hal {
 	bool enter_pnp_sleep;
 	bool wake_from_pnp_sleep;
 	bool wow_enabled;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0))
+	__kernel_old_time_t last_suspend_sec;
+#else
 	__kernel_time_t last_suspend_sec;
+#endif
 	u32 wowlan_fwsize;
 	u8 *wowlan_firmware;
 


### PR DESCRIPTION
* Few days back a patch landed to mainline torvalds/linux@c766d1472c70d25ad475cf56042af1652e792b23
  which hides the original '__kernel_time_t' macro that was being used.

* Fix the build by making use of '__kernel_old_time_t' for module builds on linux >= 5.6.0

Status: builds, Installs and works fine.
Tested: ✔

Signed-off-by: dev-harsh1998 <dev-harsh1998@hotmail.com>