### PR TITLE
Allow compilation from another running kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/sh
 CC = gcc
-KVER  ?= $(shell uname -r)
+KVER  ?= $(if $(KERNELRELEASE),$(KERNELRELEASE),$(shell uname -r))
 KSRC := /lib/modules/$(KVER)/build
 FIRMWAREDIR := /lib/firmware/
 PWD := $(shell pwd)


### PR DESCRIPTION
DKMS doesn't set KVER, it sets KERNELRELEASE which makes the build for another kernel link against the running kernel.
Set KVER conditionaly to KERNELRELEASE if this one is set, otherwise, fallback to the old behavior.