### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ rtw_8723de  rtw_8723d  rtw_8822be  rtw_8822b  rtw_8822ce  rtw_8822c  rtw_core  a
 
 Any others WILL interfere!
 
+### Example for detecting wifi for rtw_8723de(It is no longer rtl8723de)
+* sudo modprobe -r rtw_8723de.
+* sudo modprobe rtw_8723de.
+
 #### Option configuration
 If it turns out that your system needs one of the configuration options, then do the following:
 


### PR DESCRIPTION
## CHANGE
* added instruction to detect wifi for newer driver names after "sudo make install" step as it was creating confusion with the popularly used instructions found here(It did for me) - http://ubuntuhandbook.org/index.php/2018/08/no-wifi-adapter-found-hp-laptops-ubuntu-18-04/